### PR TITLE
Added post sharing via link(url)- copy link + navigator.share

### DIFF
--- a/frontend/src/pages/FoodDetailPage.js
+++ b/frontend/src/pages/FoodDetailPage.js
@@ -1,7 +1,7 @@
 // src/pages/FoodDetailPage.js
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Clock, Heart, Share2, MapPin, Calendar, Package, Tag, MessageCircle } from 'lucide-react';
+import { ArrowLeft, Clock, Heart, Share2, MapPin, Calendar, Package, Tag, MessageCircle, Copy, Share } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import apiService from '../services/apiService';
 
@@ -40,11 +40,76 @@ const FoodDetailPage = () => {
     setIsFavorite(!isFavorite);
   };
 
-  const shareItem = () => {
-    // Implement share functionality
-    console.log('Sharing food item:', food);
+  // const shareItem = () => {
+  //   // Implement share functionality
+  //   console.log('Sharing food item:', food);
+  // };
+  const [showShareMenu, setShowShareMenu] = useState(false);
+  const shareMenuRef = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (shareMenuRef.current && !shareMenuRef.current.contains(e.target)) {
+        setShowShareMenu(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const shareItem = async () => {
+    const shareUrl = `${window.location.origin}/food/${food.food_id}`;
+  
+    try {
+      if (navigator.share) {
+        // Mobile devices: use native share dialog
+        await navigator.share({
+          title: food.title,
+          text: `Check out this free food on FoodShare!`,
+          url: shareUrl,
+        });
+      } else {
+        // Desktop: fallback to clipboard
+        await navigator.clipboard.writeText(shareUrl);
+        alert("Link copied to clipboard!");
+      }
+    } catch (error) {
+      console.error("Error sharing link:", error);
+      alert("Could not share the link.");
+    }
   };
 
+  const handleShareOption = async (type) => {
+    const shareUrl = `${window.location.origin}/food/${food.food_id}`;
+    setShowShareMenu(false);
+  
+    if (type === 'copy') {
+      try {
+        await navigator.clipboard.writeText(shareUrl);
+        alert("Link copied to clipboard!");
+      } catch (err) {
+        console.error("Clipboard failed:", err);
+      }
+    }
+  
+    if (type === 'native') {
+      try {
+        if (navigator.share) {
+          await navigator.share({
+            title: food.title,
+            text: `Check out this food on FoodShare!`,
+            url: shareUrl,
+          });
+        } else {
+          alert("Native share not supported.");
+        }
+      } catch (err) {
+        console.error("Native share failed:", err);
+      }
+    }
+  };
+  
   const handleContactOwner = () => {
     if (!currentUser) {
       navigate('/login');  // 로그인되지 않은 경우 로그인 페이지로 리다이렉트
@@ -146,9 +211,33 @@ const FoodDetailPage = () => {
             <button onClick={toggleFavorite} className={`${isFavorite ? 'text-red-500' : 'text-gray-400'}`}>
               <Heart size={20} fill={isFavorite ? "currentColor" : "none"} />
             </button>
-            <button onClick={shareItem} className="text-gray-400">
+            <div className="flex space-x-3" ref={shareMenuRef}>
+            <button
+              onClick={() => setShowShareMenu(prev => !prev)}
+              className="text-gray-400"
+            >
               <Share2 size={20} />
             </button>
+
+            {showShareMenu && (
+              <div className="absolute right-0 mt-2 w-40 bg-white border rounded shadow z-50 text-sm">
+                <button
+                  onClick={() => handleShareOption('copy')}
+                  className="flex items-center gap-2 w-full text-left px-4 py-2 hover:bg-gray-100"
+                  >
+                    <Copy size={16} />
+                    <span>Copy link</span>
+                </button>
+                <button
+                  onClick={() => handleShareOption('native')}
+                  className="flex items-center gap-2 w-full text-left px-4 py-2 hover:bg-gray-100"
+                  >
+                    <Share size={16} />
+                    <span>Share on…</span>
+                </button>
+              </div>
+            )}
+          </div>
           </div>
         </div>
       </div>

--- a/frontend/src/pages/MainPage.js
+++ b/frontend/src/pages/MainPage.js
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Search, Plus, MessageCircle, Clock, Package, Tag, MapPin, Heart, Share2, User, Bell, Filter, ShoppingBag, Map } from 'lucide-react';
+import { Search, Plus, MessageCircle, Clock, Package, Tag, MapPin, Heart, Share2, User, Bell, Filter, ShoppingBag, Map, Copy, Share } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import apiService from '../services/apiService';
 import '../MainPage.css';
@@ -305,9 +305,61 @@ const MainPage = () => {
     }
   };
 
-  const shareItem = (e, item) => {
+  // const shareItem = (e, item) => {
+  //   e.stopPropagation();
+  //   console.log('Sharing item:', item);
+  // };
+
+  const shareMenuRef = useRef(null);
+  const [activeShareId, setActiveShareId] = useState(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (shareMenuRef.current && !shareMenuRef.current.contains(e.target)) {
+        setActiveShareId(null);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+  
+  const toggleShareMenu = (e, itemId) => {
     e.stopPropagation();
-    console.log('Sharing item:', item);
+    setActiveShareId(prev => (prev === itemId ? null : itemId));
+  };
+  
+  const handleShareOption = async (type, item) => {
+    const shareUrl = `${window.location.origin}/food/${item.id}`;
+    setActiveShareId(null);
+  
+    if (type === 'copy') {
+      try {
+        await navigator.clipboard.writeText(shareUrl);
+        alert("Link copied to clipboard!");
+      } catch (err) {
+        console.error("Clipboard failed:", err);
+      }
+    }
+  
+    if (type === 'native') {
+      try {
+        if (navigator.share) {
+          await navigator.share({
+            title: item.title,
+            text: `Check out this food on FoodShare!`,
+            url: shareUrl,
+          });
+        } else {
+          alert("Native share not supported.");
+        }
+      } catch (err) {
+        console.error("Native share failed:", err);
+      }
+    }
   };
 
   const getExpirationClass = (days) => {
@@ -609,12 +661,41 @@ const MainPage = () => {
                             >
                               <Heart size={18} />
                             </button>
-                            <button
+                            {/* <button
                               className="action-button share-btn"
                               onClick={(e) => shareItem(e, item)}
                             >
                               <Share2 size={18} />
-                            </button>
+                            </button> */}
+                            <button
+                                className="action-button share-btn"
+                                onClick={(e) => {
+                                  // e.stopPropagation();
+                                  toggleShareMenu(e, item.id);
+                                }}
+                                title="Share this post"
+                              >
+                                <Share2 size={18} />
+                              </button>
+
+                              {activeShareId === item.id && (
+                                <div ref={shareMenuRef} className="absolute right-0 mt-2 w-40 bg-white border rounded shadow z-50 text-sm" onClick={(e) => e.stopPropagation()}>
+                                  <button
+                                    onClick={() => handleShareOption('copy', item)}
+                                    className="flex items-center gap-2 w-full text-left px-4 py-2 hover:bg-gray-100"
+                                  >
+                                    <Copy size={16} />
+                                    <span>Copy link</span>
+                                  </button>
+                                  <button
+                                    onClick={() => handleShareOption('native', item)}
+                                    className="flex items-center gap-2 w-full text-left px-4 py-2 hover:bg-gray-100"
+                                  >
+                                    <Share size={16} />
+                                    <span>Share on…</span>
+                                  </button>
+                                </div>
+                              )}
                           </div>
                         </div>
 


### PR DESCRIPTION
Added sharing functionality on the share button present on: (1) the food post cards on MainPage.js  and (2) on the individual food post view (FoodDetailPage.js).

- Upon clicking the share button, users have the option to either:
    - copy the url to clipboard, or 
    - use native share menu via navigator.share for easy sharing across different platforms

- useRef is used to detect outside mouse clicks and automatically close the share popup menu if the mouse is clicked on any outside space, improving user experience